### PR TITLE
Update glowshroom.json

### DIFF
--- a/src/main/resources/data/bonsaitrees3/recipes/sapling/extendedmushrooms/glowshroom.json
+++ b/src/main/resources/data/bonsaitrees3/recipes/sapling/extendedmushrooms/glowshroom.json
@@ -29,7 +29,7 @@
       "rolls": 1,
       "chance": 0.75,
       "result": {
-        "item": "extendedmushrooms:poisonous_mushroom_stem"
+        "item": "extendedmushrooms:glowshroom_mushroom_stem"
       }
     },
     {


### PR DESCRIPTION
Noticed while playing that the bonsai trees give poisonous wood for glowshrooms instead of the unique glowshroom wood. Obviously this is just a minor bug fix, but thought you should have it all the same.